### PR TITLE
Loosen dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "test": "node tests/test.js"
   },
   "dependencies": {
-    "minimatch": "~0.1.5",
-    "glob": "~3.0.1"
+    "minimatch": "0.x",
+    "glob": "3.x"
   },
   "licenses": [{
     "type": "MIT",


### PR DESCRIPTION
Severely out of date dependencies make `npm dedupe` fail for many upstream projects (`istanbul`, in this case).

Loosening the dependency to any minor revision helps avoid this failure, while not impacting functionality whatsoever.
