### PR TITLE
Package updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,5 @@
     "glob": "^6.0.3",
     "minimatch": "^3.0.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/mklabs/node-fileset/blob/master/LICENSE-MIT"
-    }
-  ]
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "test": "node tests/test.js && node tests/test-sync.js"
   },
   "dependencies": {
-    "minimatch": "2.x",
-    "glob": "5.x"
+    "glob": "^6.0.3",
+    "minimatch": "^3.0.0"
   },
   "licenses": [
     {


### PR DESCRIPTION
2 updates to package.json.  One for license and the other to update glob and minimatch.

Note that as of glob 5, exclude patterns are supported out of the box. Maybe the dependency on minimatch isn't strictly necessary?  It's hard to tell quickly.

Since glob 6 removes support for comment and negation patterns, this may or may not be a breaking change from fileset's pov.
