### PR TITLE
Upgraded minimatch and Glob to the latest major versions 3.x and 7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "test": "node tests/test.js && node tests/test-sync.js"
   },
   "dependencies": {
-    "minimatch": "2.x",
-    "glob": "5.x"
+    "minimatch": "3.x",
+    "glob": "7.x"
   },
+  "license": "MIT",
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
Somewhere down the (latest) Karma test runner dependency path `fileset` is referenced but due to the (relatively old) `glob@5.x` version used an update fails. Hence this fork.