### PR TITLE
Update minimatch from 0.x to 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "node tests/test.js && node tests/test-sync.js"
   },
   "dependencies": {
-    "minimatch": "0.x",
+    "minimatch": "3.x",
     "glob": "5.x"
   },
   "licenses": [


### PR DESCRIPTION
I noticed a warning during the `npm install` of our app relating to `minimatch`: 

```
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

`istanbul` f.ex. depends on an old fileset version and there is a ticket already for replacing fileset entirely that I also contributed to: https://github.com/gotwarlost/istanbul/issues/638 - That being said I wonder if you would be willing to accept this PR and release a `0.2.1` version of `fileset` to get rid of the old `minimatch` version right away.
